### PR TITLE
Allowed to exclude unwanted demo content collections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,18 @@ entity instead of the ID. This plugin can be used for Link fields or Menu items.
 ````
 
 ## Hooks
+* `hook_tide_demo_content_collection_ignore` is invoked before Tide Demo Content
+  imports demo content collections. It allows other modules to exclude unwanted
+  demo content collections. When a collection is ignored, all its dependants 
+  are also automatically ignored due to missing dependencies. Ignoring the
+  `tide_demo_content:tide_media.demo` and `tide_demo_content:tide_site.demo` 
+  will exclude *all* default demo content from Tide modules except demo users.
 * `hook_tide_demo_content_entity_imported` is invoked after Tide Demo Content
-imports a demo entity.
+  imports a demo entity.
 
 ## Known issues
 * Yaml Content: [Nodes Cannot Create Menu Links Automatically](https://www.drupal.org/node/2879468)
 * Yaml Content: [Nodes Cannot Create Path Aliases](https://www.drupal.org/project/yaml_content/issues/2883434)
-* Tide Demo Content: the Import Demo Content UI only allows to import YAML
-content, it does not allow to upload files/images. Hence, entities in the
-uploaded YAML can only reference existing files/images.
+* Tide Demo Content: the Import Demo Content UI only allows to import YAML 
+  content, it does not allow to upload files/images. Hence, entities in the 
+  uploaded YAML can only reference existing files/images.

--- a/src/DemoContentRepository.php
+++ b/src/DemoContentRepository.php
@@ -8,7 +8,7 @@ use Drupal\file\Entity\File;
 use Drupal\media\MediaInterface;
 
 /**
- * Class DemoContentRepository.
+ * The Repository to manage demo content.
  *
  * @package Drupal\tide_demo_content
  */
@@ -36,7 +36,7 @@ class DemoContentRepository {
   /**
    * The entities.
    *
-   * @var array
+   * @var \Drupal\Core\Entity\EntityInterface[]
    */
   protected $entities = [];
 
@@ -44,7 +44,7 @@ class DemoContentRepository {
    * DemoContentRepository constructor.
    *
    * @param \Drupal\Core\Database\Connection $connection
-   *   Te default DB connection.
+   *   The default DB connection.
    */
   public function __construct(Connection $connection) {
     $this->connection = $connection;
@@ -56,8 +56,11 @@ class DemoContentRepository {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity.
+   *
+   * @return \Drupal\tide_demo_content\DemoContentRepository
+   *   The current repository instance.
    */
-  public function trackEntity(EntityInterface $entity) {
+  public function trackEntity(EntityInterface $entity) : DemoContentRepository {
     try {
       $data = [
         'entity_type' => $entity->getEntityTypeId(),
@@ -72,6 +75,8 @@ class DemoContentRepository {
     catch (\Exception $exception) {
       watchdog_exception('tide_demo_content', $exception);
     }
+
+    return $this;
   }
 
   /**
@@ -85,8 +90,11 @@ class DemoContentRepository {
    *   Override bundle with a custom value.
    * @param bool $tracking
    *   Whether to track the entities.
+   *
+   * @return \Drupal\tide_demo_content\DemoContentRepository
+   *   The current repository instance.
    */
-  public function addDemoEntity(EntityInterface $entity, $entity_type_id = NULL, $bundle = NULL, $tracking = TRUE) {
+  public function addDemoEntity(EntityInterface $entity, string $entity_type_id = NULL, string $bundle = NULL, bool $tracking = TRUE) : DemoContentRepository {
     $entity_type_id = $entity_type_id ?: $entity->getEntityTypeId();
     $bundle = $bundle ?: $entity->bundle();
 
@@ -94,6 +102,8 @@ class DemoContentRepository {
     if ($tracking) {
       $this->trackEntity($entity);
     }
+
+    return $this;
   }
 
   /**
@@ -103,26 +113,31 @@ class DemoContentRepository {
    *   The array of entities.
    * @param bool $tracking
    *   Whether to track the entities.
+   *
+   * @return \Drupal\tide_demo_content\DemoContentRepository
+   *   The current repository instance.
    */
-  public function addDemoEntities(array $entities, $tracking = TRUE) {
+  public function addDemoEntities(array $entities, bool $tracking = TRUE) : DemoContentRepository {
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
     foreach ($entities as $entity) {
       $this->addDemoEntity($entity, NULL, NULL, $tracking);
     }
+
+    return $this;
   }
 
   /**
    * Retrieve demo entities created in the same session.
    *
-   * @param string $entity_type_id
+   * @param string|null $entity_type_id
    *   Entity type ID, eg. node or taxonomy_term.
-   * @param string $bundle
+   * @param string|null $bundle
    *   Bundle, eg. sites, page, lading_page.
    *
-   * @return array
+   * @return \Drupal\Core\Entity\EntityInterface[]|\Drupal\Core\Entity\EntityInterface
    *   The list of entities.
    */
-  public function getDemoEntities($entity_type_id = NULL, $bundle = NULL) {
+  public function getDemoEntities(string $entity_type_id = NULL, string $bundle = NULL) {
     if ($entity_type_id) {
       if (isset($this->entities[$entity_type_id])) {
         if ($bundle) {
@@ -144,11 +159,14 @@ class DemoContentRepository {
    *
    * @param bool $untrack
    *   Whether to remove the reference of the entity from the tracking table.
+   *
+   * @return \Drupal\tide_demo_content\DemoContentRepository
+   *   The current repository instance.
    */
-  public function removeTrackedEntities($untrack = FALSE) {
+  public function removeTrackedEntities(bool $untrack = FALSE) : DemoContentRepository {
     try {
       if (!$this->trackingTableExists) {
-        return;
+        return $this;
       }
 
       $query = $this->connection->select(static::TABLE_NAME, 'demo')
@@ -168,9 +186,9 @@ class DemoContentRepository {
 
             // Collect the files from media entities to delete later.
             if ($entity instanceof MediaInterface) {
-              $field_name = ($entity->bundle() == 'image') ? 'field_media_image' : 'field_media_file';
+              $field_name = ($entity->bundle() === 'image') ? 'field_media_image' : 'field_media_file';
               if ($entity->hasField($field_name)) {
-                $fid = $entity->$field_name->target_id;
+                $fid = $entity->{$field_name}->target_id;
                 $fids_to_delete[$fid] = $fid;
               }
             }
@@ -194,6 +212,8 @@ class DemoContentRepository {
     catch (\Exception $exception) {
       watchdog_exception('tide_demo_content', $exception);
     }
+
+    return $this;
   }
 
   /**
@@ -201,11 +221,14 @@ class DemoContentRepository {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity.
+   *
+   * @return \Drupal\tide_demo_content\DemoContentRepository
+   *   The current repository instance.
    */
-  public function untrackEntity(EntityInterface $entity) {
+  public function untrackEntity(EntityInterface $entity) : DemoContentRepository {
     try {
       if (!$this->trackingTableExists) {
-        return;
+        return $this;
       }
 
       $this->connection->delete(static::TABLE_NAME)
@@ -217,6 +240,8 @@ class DemoContentRepository {
     catch (\Exception $exception) {
       watchdog_exception('tide_demo_content', $exception);
     }
+
+    return $this;
   }
 
 }

--- a/src/EventSubscriber/YamlContent.php
+++ b/src/EventSubscriber/YamlContent.php
@@ -10,7 +10,7 @@ use Drupal\yaml_content\Event\YamlContentEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Class YamlContent.
+ * Event subscriber to track entities imported by tide_demo_content.
  *
  * @package Drupal\tide_demo_content\EventSubscriber
  */
@@ -63,7 +63,7 @@ class YamlContent implements EventSubscriberInterface {
     $path = trim($loader->getContentPath(), '/');
 
     // Only track entities imported from tide_demo_content.
-    if (substr($path, -strlen(DemoContentLoader::DIRECTORY)) == DemoContentLoader::DIRECTORY) {
+    if (substr($path, -strlen(DemoContentLoader::DIRECTORY)) === DemoContentLoader::DIRECTORY) {
       $this->repository->trackEntity($event->getEntity());
       $this->moduleHandler->invokeAll('tide_demo_content_entity_imported', [
         $event->getEntity(),

--- a/src/Form/ImportForm.php
+++ b/src/Form/ImportForm.php
@@ -110,7 +110,7 @@ class ImportForm extends FormBase {
 
     $temp_dir = 'temporary://tide_demo_content';
     $demo_temp_dir = $temp_dir . '/content';
-    if (file_prepare_directory($demo_temp_dir, FILE_CREATE_DIRECTORY + FILE_MODIFY_PERMISSIONS)) {
+    if ($this->fs->prepareDirectory($demo_temp_dir, $this->fs::CREATE_DIRECTORY + $this->fs::MODIFY_PERMISSIONS)) {
       $randomiser = new Random();
       $temp_name = 'demo_content_' . $randomiser->name(16) . '.content.yml';
       $temp_file = $demo_temp_dir . DIRECTORY_SEPARATOR . $temp_name;
@@ -122,7 +122,7 @@ class ImportForm extends FormBase {
           $this->messenger()->addMessage($this->formatPlural(count($entities), '1 demo entity has been imported.', '@count demo entities have been imported.') . ' Only node and media type entities are listed below - ');
           if (!empty($entities)) {
             foreach ($entities as $entity) {
-              if ($entity->getEntityTypeId() == 'node' || $entity->getEntityTypeId() == 'media') {
+              if ($entity->getEntityTypeId() === 'node' || $entity->getEntityTypeId() === 'media') {
                 $this->messenger()->addMessage(t('@entity_type/@entity_id', [
                   '@entity_type' => $entity->getEntityTypeId(),
                   '@entity_id' => $entity->id(),

--- a/src/Plugin/ConfigFilter/TideDemoContentIgnoreFilter.php
+++ b/src/Plugin/ConfigFilter/TideDemoContentIgnoreFilter.php
@@ -33,7 +33,7 @@ class TideDemoContentIgnoreFilter extends IgnoreFilter implements ContainerFacto
   /**
    * {@inheritdoc}
    */
-  public function filterWrite($name, array $data) {
+  public function filterWrite($name, array $data) : ?array {
     if ($name === 'core.extension') {
       $excluded_modules = ['tide_demo_content' => 'tide_demo_content'];
       $data['module'] = array_diff_key($data['module'], $excluded_modules);

--- a/src/Plugin/yaml_content/process/ProcessFile.php
+++ b/src/Plugin/yaml_content/process/ProcessFile.php
@@ -70,7 +70,7 @@ class ProcessFile extends File {
    *   The file system service.
    */
   protected static function getFileSystem() : FileSystemInterface {
-    // @todo: Fix by using proper dependency injection.
+    // @todo: Fix by using proper dependency injection here.
     return \Drupal::service('file_system');
   }
 

--- a/src/Plugin/yaml_content/process/ProcessFile.php
+++ b/src/Plugin/yaml_content/process/ProcessFile.php
@@ -70,7 +70,7 @@ class ProcessFile extends File {
    *   The file system service.
    */
   protected static function getFileSystem() : FileSystemInterface {
-    // @todo: Fix by using proper dependency injection here.
+    // @todo Fix by using proper dependency injection here.
     return \Drupal::service('file_system');
   }
 

--- a/src/Plugin/yaml_content/process/ProcessFile.php
+++ b/src/Plugin/yaml_content/process/ProcessFile.php
@@ -70,7 +70,7 @@ class ProcessFile extends File {
    *   The file system service.
    */
   protected static function getFileSystem() : FileSystemInterface {
-    // @todo: Use proper dependency injection.
+    // @todo: Fix by using proper dependency injection.
     return \Drupal::service('file_system');
   }
 

--- a/src/Plugin/yaml_content/process/UriReference.php
+++ b/src/Plugin/yaml_content/process/UriReference.php
@@ -20,8 +20,7 @@ class UriReference extends Reference {
    * {@inheritdoc}
    */
   public function process(ProcessingContext $context, array &$field_data) {
-    $entity_type = $this->configuration[0];
-    $filter_params = $this->configuration[1];
+    [$entity_type, $filter_params] = $this->configuration;
 
     $entity_storage = $this->entityTypeManager->getStorage($entity_type);
 
@@ -57,6 +56,7 @@ class UriReference extends Reference {
       return $field_data['uri'];
     }
     $this->throwParamError('Unable to find referenced content', $entity_type, $filter_params);
+    return NULL;
   }
 
 }

--- a/tide_demo_content.api.php
+++ b/tide_demo_content.api.php
@@ -24,3 +24,25 @@ function hook_tide_demo_content_entity_imported(EntityInterface $entity, array $
     '%label' => $entity->label(),
   ]));
 }
+
+/**
+ * Excludes unwanted demo content collections.
+ *
+ * When a collection is ignored, all its dependants will be also ignored due to
+ * missing collections. Hence, be aware when ignoring the essential collections
+ * such as: 'tide_demo_content:tide_core.demo',
+ * 'tide_demo_content:tide_media.demo', and 'tide_demo_content:tide_site.demo'.
+ *
+ * @param array $collections
+ *   All collections which were discovered by tide_demo_content.
+ *
+ * @return string[]
+ *   The list of collection names to be excluded.
+ */
+function hook_tide_demo_content_collection_ignore(array $collections) : array {
+  $ignored_collections = ['my_module:my_unwanted_collection.demo'];
+  if (isset($collections['tide_alert:tide_alert.demo'])) {
+    $ignored_collections[] = 'tide_alert:tide_alert.demo';
+  }
+  return $ignored_collections;
+}

--- a/tide_demo_content.services.yml
+++ b/tide_demo_content.services.yml
@@ -10,6 +10,7 @@ services:
       - '@yaml_content.content_loader'
       - '@messenger'
       - '@string_translation'
+      - '@file_system'
   tide_demo_content.event_subscriber.yaml_content:
     class: \Drupal\tide_demo_content\EventSubscriber\YamlContent
     arguments: [ '@tide_demo_content.repository', '@module_handler' ]


### PR DESCRIPTION
## Changes
1. Introduce a new hook allowing other modules (and consumer sites) to exclude unwanted demo collections.
2. Refactored some code for Drupal 9 compatibility.

On-behalf-of: @salsadigitalauorg <sonny@salsadigital.com.au>