### PR TITLE
Fixed incorrect accordion_style and accordion_body format with html content.

### DIFF
--- a/demo_content/content/tide_landing_page/landing_page_01.content.yml
+++ b/demo_content/content/tide_landing_page/landing_page_01.content.yml
@@ -130,20 +130,29 @@
     - entity: paragraph
       type: accordion
       field_paragraph_title: Accordion header (basic)
-      field_paragraph_accordion_style: numbered
+      field_paragraph_accordion_style: basic
       field_paragraph_accordion:
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #1'
-          field_paragraph_accordion_body: '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
+          field_paragraph_accordion_body:
+            - format: rich_text
+              value: |
+                '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #2'
-          field_paragraph_accordion_body: '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
+          field_paragraph_accordion_body:
+            - format: rich_text
+              value: |
+                '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #3'
-          field_paragraph_accordion_body: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
+          field_paragraph_accordion_body:
+            - format: rich_text
+              value: |
+                '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
     # Accordion - numbered.
     - entity: paragraph
       type: accordion
@@ -153,15 +162,24 @@
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #1'
-          field_paragraph_accordion_body: '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
+          field_paragraph_accordion_body:
+            - format: rich_text
+              value: |
+                '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #2'
-          field_paragraph_accordion_body: '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
+          field_paragraph_accordion_body:
+            - format: rich_text
+              value: |
+                '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #3'
-          field_paragraph_accordion_body: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
+          field_paragraph_accordion_body:
+            - format: rich_text
+              value: |
+                '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
     # Card carousel.
     - entity: paragraph
       type: card_carousel


### PR DESCRIPTION
Issue: 
Incorrect accordion_style for Accordion header (basic)
Incorrect accordion_body format for html content
--
<img width="897" alt="Screenshot 2021-07-25 at 10 11 11 AM" src="https://user-images.githubusercontent.com/14798955/126888215-4d6ed493-a13e-4d76-9341-bbe367f8b340.png">

Fixed to correct accordion_style : basic and converted text format to rich_text