### PR TITLE
Fixed module compatibility with tide_edit_protection.

### DIFF
--- a/src/Form/ImportForm.php
+++ b/src/Form/ImportForm.php
@@ -119,7 +119,7 @@ class ImportForm extends FormBase {
         try {
           $this->contentLoader->setContentPath($temp_dir);
           $entities = $this->contentLoader->loadContent($temp_name);
-          $this->messenger()->addMessage($this->formatPlural(count($entities), '1 demo entity has been imported.', '@count demo entities have been imported.') . ' Only node and media type entities are listed below - ');
+          $this->messenger()->addMessage($this->t($this->formatPlural(count($entities), '1 demo entity has been imported.', '@count demo entities have been imported.') . ' Only node and media type entities are listed below - '));
           if (!empty($entities)) {
             foreach ($entities as $entity) {
               if ($entity->getEntityTypeId() == 'node' || $entity->getEntityTypeId() == 'media') {


### PR DESCRIPTION
Issue:
When tide_edit_protection and tide_demo_content both are enabled. error is thrown on page /admin/content/import_demo_content.
Though content gets imported the error is noticed. 
<img width="1447" alt="Screenshot 2021-07-25 at 11 38 13 AM" src="https://user-images.githubusercontent.com/14798955/126889623-3ae5218d-0843-49a8-aba6-4fef50c8e8e4.png">

Changed: Added translation.
Issue Resolved
