### PR TITLE
[SRM-124] Copy across taxonomies from content-vic

### DIFF
--- a/demo_content/content/tide_event/taxonomy_term/event.content.yml
+++ b/demo_content/content/tide_event/taxonomy_term/event.content.yml
@@ -3,3 +3,28 @@
   name: 'Demo Event Category'
   status: 1
   uuid: 11dede11-10c0-111e1-1100-000000000050
+- entity: taxonomy_term
+  vid: event_requirements
+  name: 'Accessible venue'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000051
+- entity: taxonomy_term
+  vid: event_requirements
+  name: 'Child friendly'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000052
+- entity: taxonomy_term
+  vid: event_requirements
+  name: 'Free admission'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000053
+- entity: taxonomy_term
+  vid: event_requirements
+  name: 'Online event'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000054
+- entity: taxonomy_term
+  vid: event_requirements
+  name: 'Seniors'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000055

--- a/demo_content/content/tide_grant/taxonomy_term/grant.content.yml
+++ b/demo_content/content/tide_grant/taxonomy_term/grant.content.yml
@@ -1,0 +1,20 @@
+- entity: taxonomy_term
+  vid: audience
+  name: 'Individual'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000070
+- entity: taxonomy_term
+  vid: audience
+  name: 'Business'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000071
+- entity: taxonomy_term
+  vid: audience
+  name: 'Government'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000072
+- entity: taxonomy_term
+  vid: audience
+  name: 'Not-for-profit groups'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000073

--- a/demo_content/content/tide_news/taxonomy_term/news.content.yml
+++ b/demo_content/content/tide_news/taxonomy_term/news.content.yml
@@ -1,0 +1,80 @@
+- entity: taxonomy_term
+  vid: location
+  name: 'Eastern Metropolitan Region'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000080
+- entity: taxonomy_term
+  vid: location
+  name: 'Eastern Victoria Region'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000081
+- entity: taxonomy_term
+  vid: location
+  name: 'Melbourne metropolitan'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000082
+- entity: taxonomy_term
+  vid: location
+  name: 'Northern Victorian Region'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000083
+- entity: taxonomy_term
+  vid: location
+  name: 'South Eastern Metropolitan Region'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000084
+- entity: taxonomy_term
+  vid: location
+  name: 'Southern Metropolitan Region'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000085
+- entity: taxonomy_term
+  vid: location
+  name: 'Western Metropolitan Region'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000086
+- entity: taxonomy_term
+  vid: location
+  name: 'Western Victoria Region'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000087
+- entity: taxonomy_term
+  vid: location
+  name: 'Eastern metropolitan Melbourne'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000088
+- entity: taxonomy_term
+  vid: location
+  name: 'Northern metropolitan Melbourne'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000089
+- entity: taxonomy_term
+  vid: location
+  name: 'Southern metropolitan Melbourne'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000090
+- entity: taxonomy_term
+  vid: location
+  name: 'Southeastern metropolitan Melbourne'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000091
+- entity: taxonomy_term
+  vid: location
+  name: 'Western metropolitan Melbourne'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000092
+- entity: taxonomy_term
+  vid: location
+  name: 'Eastern Victoria'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000093
+- entity: taxonomy_term
+  vid: location
+  name: 'Northern Victoria'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000094
+- entity: taxonomy_term
+  vid: location
+  name: 'Western Victoria'
+  status: 1
+  uuid: 11dede11-10c0-111e1-1100-000000000095

--- a/tide_demo_content.tide_demo_content.yml
+++ b/tide_demo_content.tide_demo_content.yml
@@ -37,6 +37,7 @@ tide_grant.demo:
       - tide_demo_content:tide_site.demo
       - tide_demo_content:tide_media.demo
   content:
+    - 'tide_grant/taxonomy_term'
     - 'tide_grant/tc-9a-grant.yml'
     - 'tide_grant/tc-9b-grant.yml'
 tide_landing_page.demo:
@@ -78,6 +79,7 @@ tide_news.demo:
       - tide_demo_content:tide_site.demo
       - tide_demo_content:tide_media.demo
   content:
+    - 'tide_news/taxonomy_term'
     - 'tide_news/news_01.content.yml'
     - 'tide_news/news-1.yml'
     - 'tide_news/news-2.yml'


### PR DESCRIPTION
Changed:
1) Add existing taxonomies for tide_grant and tide_news as demo content.