### PR TITLE
Fixes a redeclare issue

### DIFF
--- a/demo_content/content/tide_landing_page/landing_page_01.content.yml
+++ b/demo_content/content/tide_landing_page/landing_page_01.content.yml
@@ -397,7 +397,7 @@
   name: 'Demo Site'
   status: 1
   uuid: 11dede11-10c0-111e1-1100-000000000040
-  field_site_domains: 'demo.vic.gov.au'
+  field_site_domains: 'www.demo.vic.gov.au'
   field_acknowledgement_to_country: 'The Victorian Government acknowledges Aboriginal and Torres Strait Islander people as the Traditional Custodians of the land and acknowledges and pays respect to their Elders, past and present.'
   field_site_main_menu:
     - '#process':
@@ -423,7 +423,7 @@
   name: 'Another Demo Site'
   status: 1
   uuid: 11dede11-10c0-111e1-1100-000000000045
-  field_site_domains: 'another.demo.vic.gov.au'
+  field_site_domains: 'www.another.demo.vic.gov.au'
   field_acknowledgement_to_country: 'The Victorian Government acknowledges Aboriginal and Torres Strait Islander people as the Traditional Custodians of the land and acknowledges and pays respect to their Elders, past and present.'
   field_site_main_menu:
     - '#process':

--- a/src/Plugin/yaml_content/process/ProcessFile.php
+++ b/src/Plugin/yaml_content/process/ProcessFile.php
@@ -6,7 +6,6 @@ use Drupal\Component\Render\PlainTextOutput;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\yaml_content\Plugin\ProcessingContext;
 use Drupal\yaml_content\Plugin\yaml_content\process\File;
-use Drupal\Core\File\FileSystemInterface;
 
 /**
  * Plugin for processing and loading a file attachment.


### PR DESCRIPTION
### Issue
1. 
```bash
==> Enabling site-specific modules
PHP Fatal error:  Cannot use Drupal\Core\File\FileSystemInterface as FileSystemInterface because the name is already in use in /app/docroot/modules/contrib/tide_demo_content/src/Plugin/yaml_content/process/ProcessFile.php on line 9
 [warning] Drush command terminated abnormally.
```
`use Drupal\Core\File\FileSystemInterface;` been declared twice. 

2. `yaml_content` module doesn't allow field value overridden. so `field_site_domains` should consistent with https://github.com/dpc-sdp/tide_demo_content/blob/develop/demo_content/content/tide_site/site.content.yml#L6 , otherwise, it will try to create another entry.

### Fix
1. remove one of them.
2. change 'demo.vic.gov.au' to 'www.demo.vic.gov.au'