### PR TITLE
release/3.0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "patches": {
       "drupal/yaml_content": {
         "Alter parsed values before nodes created. - https://www.drupal.org/project/yaml_content/issues/3261689#comment-15167530": "https://www.drupal.org/files/issues/2023-07-27/yaml_content-3261689_4.patch",
-        "Warnings when importing menus using module. - https://www.drupal.org/project/yaml_content/issues/3340448": "https://www.drupal.org/files/issues/2023-02-14/warnings-when-importing_3340448_5.patch"
+        "Warnings when importing menus using module. - https://www.drupal.org/project/yaml_content/issues/3340448": "https://www.drupal.org/files/issues/2023-07-28/warnings-when-importing_3340448_7.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "extra": {
     "patches": {
       "drupal/yaml_content": {
-        "Alter parsed values before nodes created. - https://www.drupal.org/project/yaml_content/issues/3261689#comment-14393366": "https://www.drupal.org/files/issues/2022-02-01/yaml_content-3261689_2.patch",
+        "Alter parsed values before nodes created. - https://www.drupal.org/project/yaml_content/issues/3261689#comment-15167530": "https://www.drupal.org/files/issues/2023-07-27/yaml_content-3261689_4.patch",
         "Warnings when importing menus using module. - https://www.drupal.org/project/yaml_content/issues/3340448": "https://www.drupal.org/files/issues/2023-02-14/warnings-when-importing_3340448_5.patch"
       }
     }

--- a/demo_content/content/tide_landing_page/landing_page_01.content.yml
+++ b/demo_content/content/tide_landing_page/landing_page_01.content.yml
@@ -36,7 +36,7 @@
             name: 'Demo: Parliament of Victoria'
   field_landing_page_intro_text: Nulla ultricies dignissim leo, posuere vestibulum erat cursus vitae
   field_landing_page_summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus.
-  field_landing_page_hero_theme: light
+  field_landing_page_hero_theme: dark
   field_landing_page_bg_colour: white
   # Hero banner.
   field_landing_page_hero_banner:
@@ -135,15 +135,21 @@
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #1'
-          field_paragraph_accordion_body: '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
+          field_paragraph_accordion_body:
+          - format: rich_text
+            value: '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #2'
-          field_paragraph_accordion_body: '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
+          field_paragraph_accordion_body:
+          - format: rich_text
+            value: '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #3'
-          field_paragraph_accordion_body: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
+          field_paragraph_accordion_body:
+          - format: rich_text
+            value: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
     # Accordion - numbered.
     - entity: paragraph
       type: accordion
@@ -153,15 +159,21 @@
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #1'
-          field_paragraph_accordion_body: '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
+          field_paragraph_accordion_body:
+          - format: rich_text
+            value: '<p>Phasellus in varius leo. Suspendisse potenti. Donec scelerisque cursus ex varius efficitur. Vivamus pretium nisi sed libero accumsan mattis. Duis convallis, velit eget varius tempus, orci erat aliquam sem, eget porta mauris nisl at mauris.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #2'
-          field_paragraph_accordion_body: '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
+          field_paragraph_accordion_body:
+          - format: rich_text
+            value: '<p>Mauris tincidunt tincidunt felis vel tempus. Vestibulum rhoncus blandit justo quis finibus. Phasellus lacus lectus, sollicitudin sed posuere non, ultricies ut quam.</p>'
         - entity: paragraph
           type: accordion_content
           field_paragraph_accordion_name: 'Accordion #3'
-          field_paragraph_accordion_body: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
+          field_paragraph_accordion_body:
+          - format: rich_text
+            value: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt sit amet ligula sit amet lacinia. In a leo nec tortor aliquet faucibus. Quisque nec congue ligula, vitae condimentum tellus.</p>'
     # Card carousel.
     - entity: paragraph
       type: card_carousel

--- a/src/Form/ImportForm.php
+++ b/src/Form/ImportForm.php
@@ -5,12 +5,12 @@ namespace Drupal\tide_demo_content\Form;
 use Drupal\Component\Serialization\Exception\InvalidDataTypeException;
 use Drupal\Component\Utility\Random;
 use Drupal\Core\File\FileSystem;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\Core\Url;
-use Drupal\Core\File\FileSystemInterface;
 use Drupal\yaml_content\ContentLoader\ContentLoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tide_demo_content.api.php
+++ b/tide_demo_content.api.php
@@ -5,8 +5,8 @@
  * Hooks provided by Tide Demo Content module.
  */
 
-use Drupal\yaml_content\ContentLoader\ContentLoaderInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\yaml_content\ContentLoader\ContentLoaderInterface;
 
 /**
  * Reacts when a demo entity is imported.


### PR DESCRIPTION
Changes

1. [SRM-978] Reroll patch for `yaml_content`
2. [fix: 🐛 use dark theme header, set accordions to rich_text (](https://github.com/dpc-sdp/tide_demo_content/pull/66/commits/32f704bc958be0f72acd442fddb227fcc4cff289)https://github.com/dpc-sdp/tide_demo_content/pull/53[)](https://github.com/dpc-sdp/tide_demo_content/pull/66/commits/32f704bc958be0f72acd442fddb227fcc4cff289)

[SRM-978]: https://digital-vic.atlassian.net/browse/SRM-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ