### PR TITLE
[SDPAP-8241] Add contributor users.

### DIFF
--- a/demo_content/content/tide_site/user.content.yml
+++ b/demo_content/content/tide_site/user.content.yml
@@ -113,3 +113,70 @@
         args:
           - 'user_role'
           - id: 'previewer'
+# Contributors
+- entity: user
+  status: 1
+  name: 'contributor1.test@example.com'
+  mail: 'contributor1.test@example.com'
+  pass: DpcFakePass
+  roles:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'user_role'
+          - id: 'contributor'
+  field_user_site:
+    - '#process':
+        callback: reference
+        args:
+          - taxonomy_term
+          - vid: sites
+            name: 'Demo Site'
+        dependency: 'site.content.yml'
+    - '#process':
+        callback: reference
+        args:
+          - taxonomy_term
+          - vid: sites
+            name: 'Another Demo Site'
+        dependency: 'site.content.yml'
+    - '#process':
+        callback: reference
+        args:
+          - taxonomy_term
+          - vid: sites
+            name: 'Melbourne Web Demo'
+        dependency: 'site.content.yml'
+- entity: user
+  status: 1
+  name: 'contributor2.test@example.com'
+  mail: 'contributor2.test@example.com'
+  pass: DpcFakePass
+  roles:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'user_role'
+          - id: 'contributor'
+  field_user_site:
+    - '#process':
+        callback: reference
+        args:
+          - taxonomy_term
+          - vid: sites
+            name: 'Demo Site'
+        dependency: 'site.content.yml'
+    - '#process':
+        callback: reference
+        args:
+          - taxonomy_term
+          - vid: sites
+            name: 'Another Demo Site'
+        dependency: 'site.content.yml'
+    - '#process':
+        callback: reference
+        args:
+          - taxonomy_term
+          - vid: sites
+            name: 'Melbourne Web Demo'
+        dependency: 'site.content.yml'


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8241

### Change
yaml_content has `dependency` key in the plugin definition, but it doesn't work on our end, as we use our customised content loader; I guess it might be related to namespacing and file path issues, while I don't think it is necessary to debug it.

---

Fixed by moving `user.content.yml` to `demo_content/content/tide_site` directory, it works fine with loading dependencies. 

I couldn't find any bad side effects while building demo content.

### Screenshot
![CleanShot 2023-10-18 at 12 43 12](https://github.com/dpc-sdp/tide_demo_content/assets/8788145/5cb02680-ae0c-49ab-b228-403a35693f66)
